### PR TITLE
When using itfocus as a prefix to a command, restore previous itset

### DIFF
--- a/gdb/itset.c
+++ b/gdb/itset.c
@@ -4168,13 +4168,13 @@ itfocus_command (char *spec, int from_tty)
 	{
 	  struct execution_context saved_ctx;
 
-	  save_current_itset ();
+	  old_chain = save_current_itset ();
 	  current_itset = itset;
 
 	  saved_ctx = *get_current_context ();
 	  make_cleanup (restore_current_context_cleanup, &saved_ctx);
 
-	  old_chain = make_cleanup_restore_current_thread ();
+	  make_cleanup_restore_current_thread ();
 
 	  switch_to_itset (itset);
 


### PR DESCRIPTION
Notice that after the "interrupt" call, there is a + but no *. With this
patch, it goes back to being a star.

```
(gdb) info threads
  Id   Target Id         Frame
* 1.1  Thread 0x7ffff7fc7740 (LWP 26465) "simple" 0x00007ffff7bc566b in pthread_join (threadid=140737345709824, thread_return=0x0) at pthread_join.c:92
  1.2  Thread 0x7ffff77f6700 (LWP 26469) "simple" 0x00007ffff78b7f3d in nanosleep () at ../sysdeps/unix/syscall-template.S:81
  1.3  Thread 0x7ffff6ff5700 (LWP 26470) "simple" 0x00007ffff78b7f3d in nanosleep () at ../sysdeps/unix/syscall-template.S:81
  1.4  Thread 0x7ffff67f4700 (LWP 26471) "simple" 0x00007ffff78b7f3d in nanosleep () at ../sysdeps/unix/syscall-template.S:81
  1.5  Thread 0x7ffff5ff3700 (LWP 26472) "simple" 0x00007ffff78b7f3d in nanosleep () at ../sysdeps/unix/syscall-template.S:81
(gdb) dt1.1 : t1.1> itfocus (1.4) interrupt
(gdb) dt1.1 : t1.1> status
    Id   Target Id         Status
  1 (process 26465) [/home/emaisin/src/itsets-tests/simple/simple]
+   1.1  Thread 0x7ffff7fc7740 (LWP 26465) "simple" 0x00007ffff7bc566b in pthread_join (threadid=140737345709824, thread_return=0x0) at pthread_join.c:92
    1.2  Thread 0x7ffff77f6700 (LWP 26469) "simple" 0x00007ffff78b7f3d in nanosleep () at ../sysdeps/unix/syscall-template.S:81
    1.3  Thread 0x7ffff6ff5700 (LWP 26470) "simple" 0x00007ffff78b7f3d in nanosleep () at ../sysdeps/unix/syscall-template.S:81
    1.4  Thread 0x7ffff67f4700 (LWP 26471) "simple" 0x00007ffff78b7f3d in nanosleep () at ../sysdeps/unix/syscall-template.S:81
    1.5  Thread 0x7ffff5ff3700 (LWP 26472) "simple" 0x00007ffff78b7f3d in nanosleep () at ../sysdeps/unix/syscall-template.S:81
```
